### PR TITLE
Upgrade checkssl to v1.18.1

### DIFF
--- a/checkssl.rb
+++ b/checkssl.rb
@@ -1,13 +1,13 @@
 require 'formula'
 
 class Checkssl < Formula
-  VERSION = '1.18'
+  VERSION = '1.18.1'
 
-  homepage 'https://github.com/srvrco/checkssl'
-  url "https://github.com/srvrco/checkssl/archive/v#{VERSION}.tar.gz"
-  sha256 'd731ed43749b8a37a7c8e70bf7a4244ce526fa4fb3627ec8780700b22130b5d0'
+  homepage 'https://github.com/tomorrowkey/checkssl'
+  url "https://github.com/tomorrowkey/checkssl/archive/v#{VERSION}.tar.gz"
+  sha256 '7f3b11b6c9dd50400435b63ff6bf521ec292bfdcc48657f159f27142fab53921'
   version VERSION
-  head 'https://github.com/srvrco/checkssl.git', :branch => 'master'
+  head 'https://github.com/tomorrowkey/checkssl.git', :branch => 'master'
 
   def install
     bin.install 'checkssl'


### PR DESCRIPTION
PRがマージされそうにないのでフォークしたバージョンを使うようにします。 https://github.com/srvrco/checkssl/pull/17