### PR TITLE
Fix origin url for private repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@ homebrew-self
 =========
 
 ```
-brew tap oishi-kenko/self
+$ brew tap oishi-kenko/self
+$ cd $(brew --prefix)/Library/Taps/oishi-kenko/homebrew-self
+$ git remote set-url origin git@github.com:oishi-kenko/homebrew-self.git
+$ cd -
 ```


### PR DESCRIPTION
`git credential-osxkeychain`がないよー的なメッセージが表示されるようになったので、少し修正
一度untapしてtapしなおしたら次のメッセージがでてきて、そのとおりにした解決したので、READMEに方法を書いておきます。

```console
It looks like you tapped a private repository. To avoid entering your
credentials each time you update, you can use git HTTP credential
caching or issue the following command:
  cd /opt/brew/Library/Taps/oishi-kenko/homebrew-self
  git remote set-url origin git@github.com:oishi-kenko/homebrew-self.git
```